### PR TITLE
Use license in package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -32,12 +32,7 @@
   "engines": {
     "node": ">= 0.8.0"
   },
-  "licenses": [
-    {
-      "type": "MIT",
-      "url": "http://github.com/OverZealous/gulp-task-listing/raw/master/LICENSE"
-    }
-  ],
+  "licenses":"MIT",
   "bugs": {
     "url": "https://github.com/OverZealous/gulp-task-listing/issues"
   },


### PR DESCRIPTION
Array deprecated in `npm@2.10.0`

https://github.com/npm/npm/blob/master/doc/files/package.json.md#license