### PR TITLE
Fix chalk dependency to use 1.1.3

### DIFF
--- a/package.json
+++ b/package.json
@@ -16,7 +16,7 @@
     "gulpfriendly"
   ],
   "dependencies": {
-    "chalk": "~1.1.3"
+    "chalk": "^1.1.3"
   },
   "devDependencies": {
     "gulp": "^3.6.2",

--- a/package.json
+++ b/package.json
@@ -16,7 +16,7 @@
     "gulpfriendly"
   ],
   "dependencies": {
-    "chalk": "*"
+    "chalk": "~1.1.3"
   },
   "devDependencies": {
     "gulp": "^3.6.2",


### PR DESCRIPTION
chalk relased v2 which uses node engine > 4 and has some es6 features that fails on lower nodejs versions